### PR TITLE
Update reference to example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Run `make dev-setup`.
 
 ## Configuration
 
-Create a copy of the `nifi-cluster-coordinator.example.yaml` and name it `nifi-cluster-coordinator.yaml` and update it with your cluster configurations.
+Create a copy of [nifi-cluster-coordinator.yaml](conf/nifi-cluster-coordinator.yaml) and update it with your cluster configurations.
 
 Copyright (c) 2020 Plex Systems https://www.plex.com

--- a/conf/nifi-cluster-coordinator.example.yaml
+++ b/conf/nifi-cluster-coordinator.example.yaml
@@ -1,6 +1,0 @@
-clusters:
-  - name: foo-cluster
-    cluster_host_name: 'https://foo-cluster/nifi-api'
-    cluster_ssl_cert_file: '/foo/foo-user-cert.pem'
-    cluster_ssl_ca_cert: '/foo/foo-root-ca-cert.pem'
-    cluster_ssl_key_file: '/foo/foo-root-ca-key.pem'


### PR DESCRIPTION
- Removes the `-example` suffix in the `conf/nifi-cluster-coordinator-example.yaml` file.
- Updates the README to reflect the new change and clean up the wording some.

If we want the intent to be clear that the provided configuration is an _example_, it might be valuable to rename the conf folder to example--especially if there are more files required to provide a complete example. Then all tests/documentation can refer to the examples directory. Thoughts?