### PR TITLE
Feature/garbage collect registry entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ files = $(wildcard **/*.py)
 test_files = $(wildcard **/test_*.py)
 config_file = conf/nifi-cluster-coordinator.yaml
 default_log_level = DEBUG
-state_file = conf/nifi-cluster-state.pkl
 
 run: fix
 	@python3 $(project_folder)/$(entry_file) --loglevel $(default_log_level) --configfile $(config_file)

--- a/nifi_cluster_coordinator/configuration/cluster.py
+++ b/nifi_cluster_coordinator/configuration/cluster.py
@@ -110,8 +110,8 @@ class Cluster:
     def set_registry_entries(self, configured_registries):
         """Set the cluster nifi-registry entries to their desired configuration."""
         logger = logging.getLogger(__name__)
-        logger.info(f'Setting registry clients for: {self.name}')
 
+        logger.info(f'Collecting currently configure registries for: {self.name}')
         cluster_registries = requests.get(**self._get_connection_details('/controller/registry-clients')).json()
 
         # Build dictionaries for the desired registry configuration & the current registry configuration.
@@ -127,6 +127,5 @@ class Cluster:
                 # TODO: Delete the registry.
                 logger.warn(f'Deleting {configured_registry}')
                 self._delete_registry(configured_registry)
-                pass
             else:
                 self._update_registry(desired_registry_configuration, configured_registry)

--- a/nifi_cluster_coordinator/configuration/config_loader.py
+++ b/nifi_cluster_coordinator/configuration/config_loader.py
@@ -1,6 +1,5 @@
 import yaml
 import logging
-import pickle
 from .cluster import Cluster
 from .registry import Registry
 
@@ -11,10 +10,6 @@ class Configuration:
         self.clusters = [Cluster(name=c['name'], host_name=c['host_name'], security=c['security']) for c in clusters]
         self.registries = [Registry(name=r['name'], uri=r['host_name'], description=r['description']) for r in registries]
         self.projects = projects
-
-    def save_to_file(self, save_file_location: str):
-        with open(save_file_location, 'wb') as output:
-            pickle.dump(self, output, pickle.HIGHEST_PROTOCOL)
 
 
 def load_from_file(config_file_location: str) -> Configuration:
@@ -34,6 +29,7 @@ def load_from_file(config_file_location: str) -> Configuration:
 
 
 def _build_configuration(config_definition) -> Configuration:
+    """Build a configuration object."""
     try:
         config = Configuration(
             config_definition['clusters'],

--- a/nifi_cluster_coordinator/main.py
+++ b/nifi_cluster_coordinator/main.py
@@ -19,9 +19,6 @@ def main(args):
         logger.info(f'Setting registry clients for: {cluster.name}')
         cluster.set_registry_entries(configuration.registries)
 
-    # TODO: Figure out state management, commenting out for now
-    # configuration.save_to_file(args.statefile)
-
     if args.watch:
         config_watcher.watch_configuration(args.configfile)
         # TODO: Implement actual reprocessing of configuration on file change
@@ -38,10 +35,6 @@ if __name__ == '__main__':
         '--configfile',
         help='Set the config file location.',
         required=True)
-    # parser.add_argument(
-    #     '--statefile',
-    #     help='Set the file name for storing state information.  (.pkl format)',
-    #     required=False)
     parser.add_argument(
         '--watch',
         help='Leave application running and watch the configuration file for updates.',


### PR DESCRIPTION
Implement registry entry garbage collection.  This will delete nifi-registry entries that are no longer found in the configuration file.

Deleted out the independent state management, nice idea but honestly it isn't needed.

There's still too much **registry** logic in the cluster file.  So this needs further refactoring.  But I think as we implement process group management it'll become a little clearer how we want to structure this.

Closes #5 